### PR TITLE
Single expense pages

### DIFF
--- a/src/app/(protected-routes)/togetherpay/[id]/debt/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/debt/page.tsx
@@ -1,6 +1,3 @@
-import Button from "@/components/ui/Button";
-import Headline2 from "@/components/ui/headlines/Headline2";
-import { Plus } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -11,22 +8,7 @@ interface PageProps {
 const Page: FC<PageProps> = ({ params }) => {
   return (
     <>
-      <div className="md:mt-20 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
-        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
-          california trip
-        </Headline2>
-        <p className="mt-6 text-base">
-          Transactions: <strong>23</strong>
-        </p>
-        <p className="text-base">
-          Members: <strong>6</strong>
-        </p>
-        <p className="text-base text-brand-700">
-          Total due: <strong>$57.21</strong>
-        </p>
-        <Button className="mt-6" size={"sm"}>
-          <Plus className="h-4 w-4" /> new expense
-        </Button>
+      <div className="bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
         <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
           <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
           <p className="border-b-2 border-b-navy-50 pb-2">Debt</p>
@@ -34,7 +16,7 @@ const Page: FC<PageProps> = ({ params }) => {
           <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
         </div>
       </div>
-      <div>Page</div>
+      <div>Debt</div>
     </>
   );
 };

--- a/src/app/(protected-routes)/togetherpay/[id]/debt/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/debt/page.tsx
@@ -1,0 +1,42 @@
+import Button from "@/components/ui/Button";
+import Headline2 from "@/components/ui/headlines/Headline2";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { FC } from "react";
+
+interface PageProps {
+  params: { id: string };
+}
+
+const Page: FC<PageProps> = ({ params }) => {
+  return (
+    <>
+      <div className="md:mt-20 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
+        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
+          california trip
+        </Headline2>
+        <p className="mt-6 text-base">
+          Transactions: <strong>23</strong>
+        </p>
+        <p className="text-base">
+          Members: <strong>6</strong>
+        </p>
+        <p className="text-base text-brand-700">
+          Total due: <strong>$57.21</strong>
+        </p>
+        <Button className="mt-6" size={"sm"}>
+          <Plus className="h-4 w-4" /> new expense
+        </Button>
+        <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
+          <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
+          <p className="border-b-2 border-b-navy-50 pb-2">Debt</p>
+          <Link href={`/togetherpay/${params.id}/members`}>Members</Link>
+          <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
+        </div>
+      </div>
+      <div>Page</div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(protected-routes)/togetherpay/[id]/layout.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/layout.tsx
@@ -1,0 +1,35 @@
+import Button from "@/components/ui/Button";
+import Headline2 from "@/components/ui/headlines/Headline2";
+import { Plus } from "lucide-react";
+import { FC, ReactNode } from "react";
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: FC<LayoutProps> = ({ children }) => {
+  return (
+    <>
+      <div className="md:mt-16 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
+        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
+          california trip
+        </Headline2>
+        <p className="mt-6 text-base">
+          Transactions: <strong>23</strong>
+        </p>
+        <p className="text-base">
+          Members: <strong>6</strong>
+        </p>
+        <p className="text-base text-brand-700">
+          Total due: <strong>$57.21</strong>
+        </p>
+        <Button className="mt-6">
+          <Plus className="h-4 w-4" /> new expense
+        </Button>
+      </div>
+      {children}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/app/(protected-routes)/togetherpay/[id]/members/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/members/page.tsx
@@ -1,0 +1,42 @@
+import Button from "@/components/ui/Button";
+import Headline2 from "@/components/ui/headlines/Headline2";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { FC } from "react";
+
+interface PageProps {
+  params: { id: string };
+}
+
+const Page: FC<PageProps> = ({ params }) => {
+  return (
+    <>
+      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
+        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
+          california trip
+        </Headline2>
+        <p className="mt-6 text-base">
+          Transactions: <strong>23</strong>
+        </p>
+        <p className="text-base">
+          Members: <strong>6</strong>
+        </p>
+        <p className="text-base text-brand-700">
+          Total due: <strong>$57.21</strong>
+        </p>
+        <Button className="mt-6">
+          <Plus className="h-4 w-4" /> new expense
+        </Button>
+        <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
+          <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
+          <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
+          <p className="border-b-2 border-b-navy-50 pb-2">Members</p>
+          <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
+        </div>
+      </div>
+      <div>Page</div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(protected-routes)/togetherpay/[id]/members/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/members/page.tsx
@@ -1,6 +1,3 @@
-import Button from "@/components/ui/Button";
-import Headline2 from "@/components/ui/headlines/Headline2";
-import { Plus } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -11,22 +8,7 @@ interface PageProps {
 const Page: FC<PageProps> = ({ params }) => {
   return (
     <>
-      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
-        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
-          california trip
-        </Headline2>
-        <p className="mt-6 text-base">
-          Transactions: <strong>23</strong>
-        </p>
-        <p className="text-base">
-          Members: <strong>6</strong>
-        </p>
-        <p className="text-base text-brand-700">
-          Total due: <strong>$57.21</strong>
-        </p>
-        <Button className="mt-6">
-          <Plus className="h-4 w-4" /> new expense
-        </Button>
+      <div className="bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
         <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
           <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
           <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
@@ -34,7 +16,7 @@ const Page: FC<PageProps> = ({ params }) => {
           <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
         </div>
       </div>
-      <div>Page</div>
+      <div>Members</div>
     </>
   );
 };

--- a/src/app/(protected-routes)/togetherpay/[id]/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/page.tsx
@@ -1,0 +1,42 @@
+import Button from "@/components/ui/Button";
+import Headline2 from "@/components/ui/headlines/Headline2";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { FC } from "react";
+
+interface PageProps {
+  params: { id: string };
+}
+
+const Page: FC<PageProps> = ({ params }) => {
+  return (
+    <>
+      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
+        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
+          california trip
+        </Headline2>
+        <p className="mt-6 text-base">
+          Transactions: <strong>23</strong>
+        </p>
+        <p className="text-base">
+          Members: <strong>6</strong>
+        </p>
+        <p className="text-base text-brand-700">
+          Total due: <strong>$57.21</strong>
+        </p>
+        <Button className="mt-6">
+          <Plus className="h-4 w-4" /> new expense
+        </Button>
+        <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
+          <p className="border-b-2 border-b-navy-50 pb-2">Transactions</p>
+          <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
+          <Link href={`/togetherpay/${params.id}/members`}>Members</Link>
+          <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
+        </div>
+      </div>
+      <div>Page</div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(protected-routes)/togetherpay/[id]/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/page.tsx
@@ -1,13 +1,30 @@
+import { Search } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
+import * as expenses from "@/lib/expenses.json";
+import ExpenseDetail from "@/components/ExpenseDetail";
 
 interface PageProps {
   params: { id: string };
 }
 
 const Page: FC<PageProps> = ({ params }) => {
+  const displayData = expenses.map((expense) => {
+    console.dir(expense);
+    return (
+      <ExpenseDetail
+        key={expense.id}
+        type={expense.type}
+        total={expense.total}
+        memberName={expense.member.name}
+        description={expense.description}
+        date={expense.date}
+      />
+    );
+  });
+
   return (
-    <>
+    <div>
       <div className="bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
         <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
           <p className="border-b-2 border-b-navy-50 pb-2">Transactions</p>
@@ -16,8 +33,20 @@ const Page: FC<PageProps> = ({ params }) => {
           <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
         </div>
       </div>
-      <div>Transactions</div>
-    </>
+      <div className="bg-navy-50 w-full h-1/2 px-4 flex flex-col items-center gap-7 justify-center">
+        <div className="mt-5 text-navy-200 w-full md:w-4/12 border-b-2 border-navy-200 pb-1 flex items-center gap-3">
+          <Search className="w-4 h-4" />
+          <input
+            type={"text"}
+            placeholder={"Search transactions"}
+            className="bg-navy-50 w-full"
+          />
+        </div>
+        <div className="mb-5 flex flex-col gap-3 justify-center items-center w-full md:w-4/12">
+          {displayData}
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/app/(protected-routes)/togetherpay/[id]/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/page.tsx
@@ -1,6 +1,3 @@
-import Button from "@/components/ui/Button";
-import Headline2 from "@/components/ui/headlines/Headline2";
-import { Plus } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -11,22 +8,7 @@ interface PageProps {
 const Page: FC<PageProps> = ({ params }) => {
   return (
     <>
-      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
-        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
-          california trip
-        </Headline2>
-        <p className="mt-6 text-base">
-          Transactions: <strong>23</strong>
-        </p>
-        <p className="text-base">
-          Members: <strong>6</strong>
-        </p>
-        <p className="text-base text-brand-700">
-          Total due: <strong>$57.21</strong>
-        </p>
-        <Button className="mt-6">
-          <Plus className="h-4 w-4" /> new expense
-        </Button>
+      <div className="bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
         <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
           <p className="border-b-2 border-b-navy-50 pb-2">Transactions</p>
           <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
@@ -34,7 +16,7 @@ const Page: FC<PageProps> = ({ params }) => {
           <Link href={`/togetherpay/${params.id}/recent`}>Recent activity</Link>
         </div>
       </div>
-      <div>Page</div>
+      <div>Transactions</div>
     </>
   );
 };

--- a/src/app/(protected-routes)/togetherpay/[id]/recent/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/recent/page.tsx
@@ -1,0 +1,42 @@
+import Button from "@/components/ui/Button";
+import Headline2 from "@/components/ui/headlines/Headline2";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { FC } from "react";
+
+interface PageProps {
+  params: { id: string };
+}
+
+const Page: FC<PageProps> = ({ params }) => {
+  return (
+    <>
+      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
+        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
+          california trip
+        </Headline2>
+        <p className="mt-6 text-base">
+          Transactions: <strong>23</strong>
+        </p>
+        <p className="text-base">
+          Members: <strong>6</strong>
+        </p>
+        <p className="text-base text-brand-700">
+          Total due: <strong>$57.21</strong>
+        </p>
+        <Button className="mt-6">
+          <Plus className="h-4 w-4" /> new expense
+        </Button>
+        <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
+          <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
+          <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
+          <Link href={`/togetherpay/${params.id}/members`}>Members</Link>
+          <p className="border-b-2 border-b-navy-50 pb-2">Recent activity</p>
+        </div>
+      </div>
+      <div>Page</div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(protected-routes)/togetherpay/[id]/recent/page.tsx
+++ b/src/app/(protected-routes)/togetherpay/[id]/recent/page.tsx
@@ -1,6 +1,3 @@
-import Button from "@/components/ui/Button";
-import Headline2 from "@/components/ui/headlines/Headline2";
-import { Plus } from "lucide-react";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -11,22 +8,7 @@ interface PageProps {
 const Page: FC<PageProps> = ({ params }) => {
   return (
     <>
-      <div className="md:mt-20 md:h-1/2 bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
-        <Headline2 className="text-navy-50 pt-10 uppercase tracking-widest">
-          california trip
-        </Headline2>
-        <p className="mt-6 text-base">
-          Transactions: <strong>23</strong>
-        </p>
-        <p className="text-base">
-          Members: <strong>6</strong>
-        </p>
-        <p className="text-base text-brand-700">
-          Total due: <strong>$57.21</strong>
-        </p>
-        <Button className="mt-6">
-          <Plus className="h-4 w-4" /> new expense
-        </Button>
+      <div className="bg-navy-800 text-navy-50 flex flex-col justify-center items-center">
         <div className="mt-6 gap-4 text-xs md:text-base md:w-2/6 py-1 flex items-start justify-between">
           <Link href={`/togetherpay/${params.id}`}>Transactions</Link>
           <Link href={`/togetherpay/${params.id}/debt`}>Debt</Link>
@@ -34,7 +16,7 @@ const Page: FC<PageProps> = ({ params }) => {
           <p className="border-b-2 border-b-navy-50 pb-2">Recent activity</p>
         </div>
       </div>
-      <div>Page</div>
+      <div>Recent activity</div>
     </>
   );
 };

--- a/src/components/ExpenseDetail.tsx
+++ b/src/components/ExpenseDetail.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import Headline5 from "./ui/headlines/Headline5";
+
+interface ExpenseDetailProps {
+  type: string;
+  total: number;
+  memberName: string;
+  description: string;
+  date: string;
+}
+
+const ExpenseDetail: FC<ExpenseDetailProps> = ({
+  type,
+  total,
+  memberName,
+  description,
+  date,
+}) => {
+  console.log(type);
+  return (
+    <div className="bg-white text-black w-full rounded capitalize py-5 px-3 md:px-6 flex items-start justify-between">
+      <div>
+        <Headline5>{type}</Headline5>
+        <p className="text-sm">
+          {memberName} has paid for {description}
+        </p>
+      </div>
+      <div className="flex flex-col items-end">
+        <p className="text-brand-700 font-semibold">
+          {Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: "USD",
+          }).format(total)}
+        </p>
+        <p className="text-xs">{date}</p>
+      </div>
+    </div>
+  );
+};
+
+export default ExpenseDetail;

--- a/src/components/ExpenseSummary.tsx
+++ b/src/components/ExpenseSummary.tsx
@@ -15,7 +15,7 @@ const ExpenseSummary: FC<ExpenseSummaryProps> = ({ id, name, total }) => {
 
   return (
     <Link
-      href="#"
+      href={`/togetherpay/${id}`}
       className="w-11/12 md:max-w-xl bg-navy-600 text-navy-50 inline-flex justify-between py-5 px-9 rounded-xl"
     >
       <span className="capitalize">{name}</span>

--- a/src/components/ui/headlines/Headline1.tsx
+++ b/src/components/ui/headlines/Headline1.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 
 interface Headin1Props {
   children: ReactNode;
-  className: string;
+  className?: string;
 }
 
 function Headline1({ children, className }: Headin1Props) {

--- a/src/components/ui/headlines/Headline1.tsx
+++ b/src/components/ui/headlines/Headline1.tsx
@@ -1,15 +1,22 @@
+import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
 
 interface Headin1Props {
   children: ReactNode;
+  className: string;
 }
 
-function Heading1({ children }: Headin1Props) {
+function Headline1({ children, className }: Headin1Props) {
   return (
-    <h1 className="text-black text-4xl font-semibold md:text-5xl">
+    <h1
+      className={cn([
+        "text-black text-4xl font-semibold md:text-5xl",
+        className,
+      ])}
+    >
       {children}
     </h1>
   );
 }
 
-export default Heading1;
+export default Headline1;

--- a/src/components/ui/headlines/Headline2.tsx
+++ b/src/components/ui/headlines/Headline2.tsx
@@ -1,9 +1,15 @@
+import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
 
 interface Headline2Props {
   children: ReactNode;
+  className: string;
 }
 
-export default function Headline2({ children }: Headline2Props) {
-  return <h2 className="text-3xl font-semibold md:text-4xl">{children}</h2>;
+export default function Headline2({ children, className }: Headline2Props) {
+  return (
+    <h2 className={cn(["text-3xl font-semibold md:text-4xl", className])}>
+      {children}
+    </h2>
+  );
 }

--- a/src/components/ui/headlines/Headline2.tsx
+++ b/src/components/ui/headlines/Headline2.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 
 interface Headline2Props {
   children: ReactNode;
-  className: string;
+  className?: string;
 }
 
 export default function Headline2({ children, className }: Headline2Props) {

--- a/src/components/ui/headlines/Headline5.tsx
+++ b/src/components/ui/headlines/Headline5.tsx
@@ -1,9 +1,13 @@
+import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
 
 interface Headline5Props {
   children: ReactNode;
+  className?: string;
 }
 
-export default function Headline5({ children }: Headline5Props) {
-  return <h5 className="text-xl font-semibold">{children}</h5>;
+export default function Headline5({ children, className }: Headline5Props) {
+  return (
+    <h5 className={cn(["text-xl font-semibold", className])}>{children}</h5>
+  );
 }

--- a/src/lib/expenses.json
+++ b/src/lib/expenses.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "123",
+    "type": "expense",
+    "member": {
+      "name": "Abbie"
+    },
+    "date": "3-8-2023",
+    "total": 21,
+    "description": "McDonald's"
+  },
+  {
+    "id": "456",
+    "type": "expense",
+    "member": {
+      "name": "Andres"
+    },
+    "date": "3-20-2023",
+    "total": 40,
+    "description": "Gasoline"
+  }
+]


### PR DESCRIPTION
Single expense pages, with the standard header for each and created the transactions page where it will be displayed all the group's expenses

Desktop view
<img width="1428" alt="Screenshot 2023-03-24 at 18 46 26" src="https://user-images.githubusercontent.com/97707578/227663192-f13b4e2d-b9b8-4ae6-9ca1-20c0d0af5329.png">

Mobile view
<img width="374" alt="Screenshot 2023-03-24 at 18 46 40" src="https://user-images.githubusercontent.com/97707578/227663239-e7e51a64-fd02-4a29-bce4-d20f237e69a3.png">
